### PR TITLE
Feat/GitHub pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site/
 .sass-cache/
 .jekyll-metadata
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+require 'json'
+require 'open-uri'
+versions = JSON.parse(open('https://pages.github.com/versions.json').read)
+
+gem 'github-pages', versions['github-pages']


### PR DESCRIPTION
Added a `Gemfile` to ensure local development matches version of Jekyll github-pages is using.  Also updated `.gitignore` to ignore `Gemfile.lock`
